### PR TITLE
Fix Home Assistant measurement sensors

### DIFF
--- a/renogybt/DataLogger.py
+++ b/renogybt/DataLogger.py
@@ -80,6 +80,8 @@ class DataLogger:
                 payload["unit_of_measurement"] = unit
             if device_class:
                 payload["device_class"] = device_class
+            if isinstance(json_data.get(key), (int, float)):
+                payload["state_class"] = "measurement"
 
             publish.single(
                 config_topic,
@@ -106,6 +108,8 @@ class DataLogger:
             return 'W', 'power'
         if lkey.endswith('percentage') or 'soc' in lkey:
             return '%', 'battery'
+        if 'amp_hour' in lkey or lkey.endswith('_ah'):
+            return 'Ah', None
         if lkey.endswith('frequency'):
             return 'Hz', 'frequency'
         return None, None


### PR DESCRIPTION
## Summary
- expose sensor values as measurement class in MQTT Home Assistant discovery
- recognize amp hour values

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c773ea10832fb8c581b439c1f544