### PR TITLE
Update combined battery readings

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you have multiple devices connected to a single BT-2 module (daisy chained or
 
 Supports logging data to local MQTT brokers like [Mosquitto](https://mosquitto.org/) or [Home Assistant](https://www.home-assistant.io/) dashboards. You can also log it to third party cloud services like [PVOutput](https://pvoutput.org/). See [config.ini](https://github.com/cyrils/renogy-bt1/blob/main/config.ini) for more details. Note that free PVOutput accounts have a cap of one request per minute.
 
-When multiple `device_id`s are configured (e.g. `48,49` when using a BT‑2 hub), data from each device is published to a unique MQTT topic in the form `<base_topic>/<alias>_<device_id>`. For a single device the `<device_id>` suffix is still added, ensuring every device has its own topic.
+When multiple `device_id`s are configured (e.g. `48,49` when using a BT‑2 hub), data from each device is published to a unique MQTT topic in the form `<base_topic>/<alias>_<device_id>`. For a single device the `<device_id>` suffix is still added, ensuring every device has its own topic. Up to eight battery devices can be listed and will be combined using `Utils.combine_battery_readings`.
 
 If you enable `homeassistant_discovery` under the `[mqtt]` section in `config.ini`, sensors will be automatically created in Home Assistant using MQTT discovery. Alternatively you can configure them manually as shown below:
 

--- a/renogybt/Utils.py
+++ b/renogybt/Utils.py
@@ -53,20 +53,29 @@ def add_calculated_values(data):
     return data
 
 def combine_battery_readings(data_map):
-    """Combine multiple battery readings into a single dictionary."""
+    """Combine up to eight battery readings into a single dictionary.
+
+    Calculates cumulative capacity, remaining charge, power, current and
+    charge percentage across all provided batteries.
+    """
     combined = {"device_id": "combined"}
+    if len(data_map) > 8:
+        raise ValueError("combine_battery_readings supports up to 8 batteries")
     total_capacity = 0
     total_remaining = 0
     total_power = 0
+    total_current = 0
 
     for dev_id, d in data_map.items():
         capacity = d.get("capacity") or 0
         remaining = d.get("remaining_charge") or 0
         power = d.get("power") or 0
+        current = d.get("current") or 0
 
         total_capacity += capacity
         total_remaining += remaining
         total_power += power
+        total_current += current
 
         cells = [v for k, v in d.items() if k.startswith("cell_voltage_") and isinstance(v, (int, float))]
         if cells:
@@ -81,8 +90,9 @@ def combine_battery_readings(data_map):
     combined["combined_capacity"] = round(total_capacity, 3)
     combined["combined_remaining_charge"] = round(total_remaining, 3)
     combined["combined_power"] = round(total_power, 2)
+    combined["combined_current"] = round(total_current, 2)
     if total_capacity:
-        combined["average_charge_percentage"] = round((total_remaining / total_capacity) * 100, 2)
+        combined["combined_charge_percentage"] = round((total_remaining / total_capacity) * 100, 2)
 
     return combined
 


### PR DESCRIPTION
## Summary
- allow up to eight batteries in `combine_battery_readings`
- add summed battery current to combined output
- document multiple battery support in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python3 - <<'EOF'
from renogybt import Utils
print(Utils.combine_battery_readings({'a': {'capacity': 100, 'current':10, 'remaining_charge': 20, 'voltage': 12}}))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6847e2c454f0832f8ea40d7645aa01ea