### PR TITLE
Add energy tracking and faster polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ $json_data = json_decode(file_get_contents('php://input'), true);
 ```sh
 */5 * * * * python3 /path/to/renogy-bt/example.py config.ini #runs every 5 mins
 ```
-If you want to monitor real-time data, turn on polling in `config.ini` for continues streaming (default interval is 60 secs). You may also register it as a [service](https://github.com/cyrils/renogy-bt/issues/77) for added reliability.
+If you want to monitor real-time data, turn on polling in `config.ini` for continues streaming (default interval is 10 secs). You may also register it as a [service](https://github.com/cyrils/renogy-bt/issues/77) for added reliability.
 
 ### Disclaimer
 

--- a/config.ini
+++ b/config.ini
@@ -14,7 +14,7 @@ device_id = 255 # modify if hub mode or daisy chain (see readme)
 
 [data]
 enable_polling = false # periodically read data
-poll_interval = 60 # read data interval (seconds)
+poll_interval = 10 # read data interval (seconds)
 temperature_unit = F # F = Fahrenheit, C = Celsius
 fields = # fields to log (comma separated), leave empty for all fields
 

--- a/example.py
+++ b/example.py
@@ -11,6 +11,7 @@ config_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), config_f
 config = configparser.ConfigParser(inline_comment_prefixes=('#'))
 config.read(config_path)
 data_logger: DataLogger = DataLogger(config)
+energy_file = os.path.join(os.path.dirname(config_path), 'energy_totals.json')
 
 # store battery data when reading multiple batteries
 battery_map = {}
@@ -18,6 +19,15 @@ battery_map = {}
 # the callback func when you receive data
 def on_data_received(client, data):
     Utils.add_calculated_values(data)
+    alias = config['device']['alias']
+    dev_id = data.get('device_id')
+    alias_id = f"{alias}_{dev_id}" if dev_id is not None else alias
+    Utils.update_energy_totals(
+        data,
+        interval_sec=config['data'].getint('poll_interval'),
+        file_path=energy_file,
+        alias=alias_id,
+    )
     filtered_data = Utils.filter_fields(data, config['data']['fields'])
     logging.info(f"{client.ble_manager.device.name} => {filtered_data}")
 


### PR DESCRIPTION
## Summary
- compute total energy in/out of battery and persist to JSON
- expose `update_energy_totals` helper
- log energy totals from `example.py`
- shorten default polling interval to 10 seconds

## Testing
- `python3 -m compileall -q renogybt example.py`

------
https://chatgpt.com/codex/tasks/task_e_684e9b0a2b90832f99673e125584ccc6