### PR TITLE
Fix energy calculations with mAh

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ If you have multiple devices connected to a single BT-2 module (daisy chained or
 Supports logging data to local MQTT brokers like [Mosquitto](https://mosquitto.org/) or [Home Assistant](https://www.home-assistant.io/) dashboards. You can also log it to third party cloud services like [PVOutput](https://pvoutput.org/). See [config.ini](https://github.com/cyrils/renogy-bt1/blob/main/config.ini) for more details. Note that free PVOutput accounts have a cap of one request per minute.
 
 When multiple `device_id`s are configured (e.g. `48,49` when using a BT‑2 hub), data from each device is published to a unique MQTT topic in the form `<base_topic>/<alias>_<device_id>`. For a single device the `<device_id>` suffix is still added, ensuring every device has its own topic. Up to eight battery devices can be listed and will be combined using `Utils.combine_battery_readings`.
-The combined payload also exposes `combined_energy_in_kwh` and `combined_energy_out_kwh` which sum the energy in and out across all batteries.
+The combined payload also exposes `combined_energy_in_wh` and `combined_energy_out_wh` which sum the energy in and out across all batteries.
+Energy totals for each device are written to `energy_totals.json`. Each update
+stores the accumulated mAh with a timestamp so the `energy_in_wh` and
+`energy_out_wh` values reflect the real energy transferred between polls.
 
 If you enable `homeassistant_discovery` under the `[mqtt]` section in `config.ini`, sensors will be automatically created in Home Assistant using MQTT discovery. Alternatively you can configure them manually as shown below:
 


### PR DESCRIPTION
## Summary
- compute energy totals in Wh using mAh differences between timestamped polls
- convert existing kWh totals if present
- document new `energy_in_wh`/`energy_out_wh` fields

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ed0a02754832f9cd6cd4f8eed5eba