### PR TITLE
Enable energy sensors for HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The combined payload also exposes `combined_energy_in_wh` and `combined_energy_o
 Energy totals for each device are written to `energy_totals.json`. Each update
 stores the accumulated mAh with a timestamp so the `energy_in_wh` and
 `energy_out_wh` values reflect the real energy transferred between polls.
+These totals are published as energy sensors via MQTT and can be selected
+directly in the Home Assistant energy dashboard.
 
 If you enable `homeassistant_discovery` under the `[mqtt]` section in `config.ini`, sensors will be automatically created in Home Assistant using MQTT discovery. Alternatively you can configure them manually as shown below:
 

--- a/renogybt/DataLogger.py
+++ b/renogybt/DataLogger.py
@@ -81,7 +81,10 @@ class DataLogger:
             if device_class:
                 payload["device_class"] = device_class
             if isinstance(json_data.get(key), (int, float)):
-                payload["state_class"] = "measurement"
+                if "energy" in key.lower():
+                    payload["state_class"] = "total_increasing"
+                else:
+                    payload["state_class"] = "measurement"
 
             publish.single(
                 config_topic,
@@ -112,6 +115,9 @@ class DataLogger:
             return '%', 'battery'
         if 'amp_hour' in lkey or lkey.endswith('_ah'):
             return 'Ah', None
+        if 'energy' in lkey:
+            unit = 'kWh' if 'kwh' in lkey else 'Wh'
+            return unit, 'energy'
         if lkey.endswith('frequency'):
             return 'Hz', 'frequency'
         return None, None


### PR DESCRIPTION
## Summary
- add state_class total_increasing to energy topics
- detect energy units when publishing MQTT discovery
- clarify README about energy dashboard usage

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684ed841a380832fa43d29fa2f50d9e8